### PR TITLE
Close browser at the end of final test run

### DIFF
--- a/puppeteer_environment.js
+++ b/puppeteer_environment.js
@@ -27,6 +27,7 @@ class PuppeteerEnvironment extends NodeEnvironment {
   async teardown() {
     console.log(chalk.yellow('Teardown Test Environment.'))
     await super.teardown()
+    await this.global.__BROWSER__.close()
   }
 
   runScript(script) {


### PR DESCRIPTION
When I was using this setup, Chromium was not closing after the final test run and was being interrupted when the parent Jest process quit. This fixed it for me. I'd be interested to know if anyone else had these problems or whether there is another canonical way of solving this problem!