### PR TITLE
Remove spurious global.__BROWSER__ assignment

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -10,7 +10,6 @@ const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
 module.exports = async function() {
   console.log(chalk.green('Setup Puppeteer'))
   const browser = await puppeteer.launch({})
-  global.__BROWSER__ = browser
   mkdirp.sync(DIR)
   fs.writeFileSync(path.join(DIR, 'wsEndpoint'), browser.wsEndpoint())
 }


### PR DESCRIPTION
Hey, thanks so much for this awesome example.

As I was working through it, I was trying to provide additional globals from `setup.js`. It took me a few minutes of head scratching to realize that the `__BROWSER__` global was not in fact coming from this file, but instead from [pupeteer_environment.js](https://github.com/xfumihiro/jest-puppeteer-example/blob/master/puppeteer_environment.js#L22).

Hopefully I'm right in this understanding. If so, this change should hopefully be a little more clear. Otherwise, I'd love to understand the rationale.

Thanks again for this project!