### PR TITLE
Renamed the "more global" global

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -10,7 +10,9 @@ const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
 module.exports = async function() {
   console.log(chalk.green('Setup Puppeteer'))
   const browser = await puppeteer.launch({})
-  global.__BROWSER__ = browser
+  // This global is not available inside tests but only in global teardown
+  global.__BROWSER_GLOBAL__ = browser
+  // Instead, we expose the connection details via file system to be used in tests
   mkdirp.sync(DIR)
   fs.writeFileSync(path.join(DIR, 'wsEndpoint'), browser.wsEndpoint())
 }

--- a/teardown.js
+++ b/teardown.js
@@ -8,6 +8,6 @@ const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
 
 module.exports = async function() {
   console.log(chalk.green('Teardown Puppeteer'))
-  await global.__BROWSER__.close()
+  await global.__BROWSER_GLOBAL__.close()
   rimraf.sync(DIR)
 }


### PR DESCRIPTION
Being new to Jest, I was pretty confused about the detour via file system since I was expecting `global.__BROWSER__` to be the same in every env.

Would it be an option to change one of the globals for this to be more obvious?